### PR TITLE
feat: add vite plugin for RSC

### DIFF
--- a/packages/vite-plugin-rsc/README.md
+++ b/packages/vite-plugin-rsc/README.md
@@ -1,0 +1,7 @@
+# @impalajs/vite-plugin-extract-server-components
+
+<p align="center">
+
+![impala](https://user-images.githubusercontent.com/213306/227727009-a4dc391f-efb1-4489-ad73-c3d3a327704a.png)
+
+</p>

--- a/packages/vite-plugin-rsc/package.json
+++ b/packages/vite-plugin-rsc/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@impalajs/vite-plugin-extract-server-components",
+  "version": "0.0.6",
+  "description": "",
+  "scripts": {
+    "build": "tsup src/plugin.ts --format esm --dts --clean"
+  },
+  "module": "./dist/plugin.mjs",
+  "types": "./dist/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.mjs"
+    }
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "tsup": "^6.7.0"
+  },
+  "peerDependencies": {
+    "vite": ">=4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vite-plugin-rsc/src/plugin.ts
+++ b/packages/vite-plugin-rsc/src/plugin.ts
@@ -30,6 +30,10 @@ const hasPragma = (ast: ASTNode, statement: string) =>
     );
   });
 
+/**
+ * Finds all the named and default exports of a module
+ */
+
 const getExports = (ast: ASTNode) => {
   const exports: Array<string> = [];
   ast.body?.forEach((node) => {
@@ -76,7 +80,7 @@ export default function plugin({
   clientDist?: string;
 }): Plugin {
   const clientPragma = "use client";
-  const serverPragma = "use server";
+  // const serverPragma = "use server";
   let externals = new Set<string>();
   let config: ResolvedConfig;
   let isSsr: boolean;

--- a/packages/vite-plugin-rsc/src/plugin.ts
+++ b/packages/vite-plugin-rsc/src/plugin.ts
@@ -1,0 +1,208 @@
+import { Plugin, ResolvedConfig, Manifest } from "vite";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { existsSync, readFileSync } from "node:fs";
+interface ASTNode {
+  type: string;
+  start: number;
+  end: number;
+  body?: Array<ASTNode>;
+  id?: ASTNode;
+  expression?: ASTNode;
+  declaration?: ASTNode;
+  declarations?: Array<ASTNode>;
+  name?: string;
+  specifiers?: Array<ASTNode>;
+
+  value?: string;
+  exported?: ASTNode;
+}
+
+/**
+ * Checks if the node has a string literal at the top level that matches the statement
+ */
+const hasPragma = (ast: ASTNode, statement: string) =>
+  ast.body?.some((node) => {
+    return (
+      node.type === "ExpressionStatement" &&
+      node.expression?.type === "Literal" &&
+      node.expression.value === statement
+    );
+  });
+
+const getExports = (ast: ASTNode) => {
+  const exports: Array<string> = [];
+  ast.body?.forEach((node) => {
+    if (node.type === "ExportDefaultDeclaration") {
+      exports.push("default");
+    }
+    if (node.type === "ExportNamedDeclaration") {
+      if (node.declaration?.type === "VariableDeclaration") {
+        node.declaration?.declarations?.forEach((declaration) => {
+          const name = declaration?.id?.name;
+          if (name) {
+            exports.push(name);
+          }
+        });
+        return;
+      }
+
+      if (node.declaration?.type === "FunctionDeclaration") {
+        const name = node.declaration?.id?.name;
+        if (name) {
+          exports.push(name);
+        }
+        return;
+      }
+
+      if (node.specifiers?.length) {
+        node.specifiers.forEach((specifier) => {
+          const name = specifier?.exported?.name;
+          if (name) {
+            exports.push(name);
+          }
+        });
+      }
+    }
+  });
+  return exports;
+};
+
+export default function plugin({
+  serverDist = "dist/server",
+  clientDist = "dist/static",
+}: {
+  serverDist?: string;
+  clientDist?: string;
+}): Plugin {
+  const clientPragma = "use client";
+  const serverPragma = "use server";
+  let externals = new Set<string>();
+  let config: ResolvedConfig;
+  let isSsr: boolean;
+  let isBuild: boolean;
+  let manifest: Manifest = {};
+
+  const bundleMap = new Map();
+  const clientModuleId = "virtual:client-bundle-map";
+  const resolvedClientModuleId = "\0" + clientModuleId;
+  const serverModuleId = "virtual:server-bundle-map";
+  const resolvedServerModuleId = "\0" + serverModuleId;
+
+  const clientBundleMapFilename = "client-bundle-map.json";
+  const serverBundleMapFilename = "server-bundle-map.json";
+
+  return {
+    name: "vite-plugin-extract-server-components",
+
+    config(config) {
+      config.build ||= {};
+      if (config.build.ssr) {
+        const manifestPath = path.join(
+          config.root || "",
+          clientDist,
+          "manifest.json"
+        );
+        if (existsSync(manifestPath)) {
+          manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+        }
+        config.build.rollupOptions ||= {};
+        config.build.rollupOptions.external = (id) => externals.has(id);
+      }
+    },
+
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+      isSsr = !!config.build.ssr;
+      isBuild = config.command === "build";
+    },
+    resolveId(id, source) {
+      if (id === clientModuleId) {
+        return resolvedClientModuleId;
+      }
+      if (id === serverModuleId) {
+        return resolvedServerModuleId;
+      }
+    },
+    load(id) {
+      if (id === resolvedClientModuleId) {
+        return `export default ${JSON.stringify(
+          // Yes the client bundle map is in the server dist because
+          // it's the SSR build that generates the client bundle map
+          path.join(config.root || "", serverDist, clientBundleMapFilename)
+        )}`;
+      }
+      if (id === resolvedServerModuleId) {
+        return `export default ${JSON.stringify(
+          path.join(config.root || "", clientDist, serverBundleMapFilename)
+        )}`;
+      }
+    },
+    transform(code, id) {
+      // Short circuit if the file doesn't have the literal string
+      if (!code?.includes(clientPragma)) {
+        return;
+      }
+      // Check properly for the pragma
+      const ast = this.parse(code, { sourceType: "module" });
+      const localId = path.relative(config.root || "", id);
+      if (hasPragma(ast, clientPragma)) {
+        if (isSsr) {
+          const bundlePath = pathToFileURL(
+            path.join(config.root, clientDist, manifest[localId].file)
+          );
+          externals.add(bundlePath.href);
+          if (manifest[localId]) {
+            const exports = getExports(ast);
+            const exportProxies = exports
+              .map((name) => {
+                const symbolName = `${manifest[localId].file}#${name}`;
+                bundleMap.set(symbolName, {
+                  id: symbolName,
+                  chunks: [],
+                  name,
+                  async: true,
+                });
+                const localName = name === "default" ? "DefaultExport" : name;
+
+                return `
+                import { ${
+                  name === "default" ? "default as DefaultExport" : name
+                } } from ${JSON.stringify(
+                  bundlePath.href
+                )};${localName}.$$typeof = Symbol.for("react.client.reference");${localName}.$$id=${JSON.stringify(
+                  symbolName
+                )}; export ${
+                  name === "default" ? "default DefaultExport" : `{ ${name} }`
+                } `;
+              })
+              .join("\n");
+            return {
+              code: exportProxies,
+              map: { mappings: "" },
+            };
+          }
+        } else {
+          this.emitFile({
+            type: "chunk",
+            id,
+            preserveSignature: "allow-extension",
+          });
+        }
+      }
+
+      // todo, work out how to handle server only code
+      // if (hasPragma(ast, serverPragma)) {
+      // }
+    },
+    generateBundle() {
+      if (isBuild && isSsr) {
+        this.emitFile({
+          type: "asset",
+          fileName: serverBundleMapFilename,
+          source: JSON.stringify(Object.fromEntries(bundleMap)),
+        });
+      }
+    },
+  };
+}

--- a/packages/vite-plugin-rsc/tsconfig.json
+++ b/packages/vite-plugin-rsc/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
First draft of a Vite plugin to extract server component modules. Made with reference to [simple-rsc](https://github.com/bholmesdev/simple-rsc) and Devon Govett's notes on RSC. As it stands, this is not specific to Impala (or even React).

## How it works

### Background
Generally, sites that use SSR need to do two builds with Vite, one with `--ssr` set and one without. These builds are independent of each other, and are likely to have different config etc. As a convention, SSR builds usually expect the client build to already have been done, and they may reference the `manifest.json` or `ssr-manifest.json`, which are both generated during the client build.

### Client builds

The client build happens first, and currently the only special thing that happens is that we ensure that any module that has `"use client"` is written to a chunk of its own. The manifest is written out, which we can read later to find that chunk filename.

### SSR build

The SSR build happens after the client build. To be clear, this does not refer to the actual SSR rendering - this is building the code that is used to do SSR later.

During the build, we register a `transform` hook. Whenever a module is loaded, we check if it has the `use client` pragma. We do this in two stages. First we do a quick string check. If the string is found we do a proper parse of code, and then traverse the AST to ensure that it's relevant syntax and not just random text somewhere in the file.

If it matches, then we find the module in the manifest. That will allow us to map it to a filename. We then inspect the parsed module again to check for the names of exports.

When we have the module id, filename and names of exports, we can generate the bundle map. For export we generate an entry in the form:

```js
{
         id: "module-name.js#default",
         chunks: [],
         name: "default",
         async: true,
}
```

This is persisted to JSON  at the end of the build.

We then replace the module code that is returned with something like the following:

```js
import DefaultExport from "file://path/to/client/module-name.js";
DefaultExport.$$typeof = Symbol.for("react.client.reference");
DefaultExport.$$id="module-name.js#default"; 
export default DefaultExport;
```

This will then be included in the SSR bundle instead of the client code.

To make it easier to find the module map later, we also register a virtual module which lets us import `"virtual:client-bundle-map"` in our server code and get the filename to the JSON.
