### PR TITLE
fix: Ensure users can exit from framework prompt step

### DIFF
--- a/packages/create-impala/src/cli.ts
+++ b/packages/create-impala/src/cli.ts
@@ -42,7 +42,7 @@ export async function createImpala() {
     ],
   });
 
-  if (isCancel(language)) {
+  if (isCancel(framework)) {
     outro("Cancelled");
     return;
   }


### PR DESCRIPTION
Super minor copy/paste bug, stops users from canceling at the 'Framework' step.