### PR TITLE
fix: ignore query string when routing

### DIFF
--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -69,7 +69,7 @@ export async function createServer() {
 
       const router = routerForModules(routeModules);
 
-      const result = router.lookup(req.originalUrl);
+      const result = router.lookup(req.path);
 
       if (!result) {
         res.status(404).end("404");


### PR DESCRIPTION
Use the request path rather than the full URL when routing. Fixes #26 