### PR TITLE
fix(core): use originalUrl for dev routing

### DIFF
--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -69,7 +69,7 @@ export async function createServer() {
 
       const router = routerForModules(routeModules);
 
-      const result = router.lookup(req.path);
+      const result = router.lookup(req.originalUrl);
 
       if (!result) {
         res.status(404).end("404");


### PR DESCRIPTION
Use req.originalUrl to avoid middleware messing up the route