### PR TITLE
fix: use baseUrl for dev routing

### DIFF
--- a/packages/core/src/dev.ts
+++ b/packages/core/src/dev.ts
@@ -69,7 +69,7 @@ export async function createServer() {
 
       const router = routerForModules(routeModules);
 
-      const result = router.lookup(req.originalUrl);
+      const result = router.lookup(req.baseUrl);
 
       if (!result) {
         res.status(404).end("404");


### PR DESCRIPTION
Correctly handle paths in dev, as the previous fox still didn't work properly for routing paths with query params