### PR TITLE
fix: Links to GH repo in templates

### DIFF
--- a/templates/preact-js/README.md
+++ b/templates/preact-js/README.md
@@ -16,4 +16,4 @@ When you're ready to build for production, run:
 npm run build
 ```
 
-See [the GitHub repo](https://githb.com/ascorbic/impala) for more help.
+See [the GitHub repo](https://github.com/ascorbic/impala) for more help.

--- a/templates/preact-ts/README.md
+++ b/templates/preact-ts/README.md
@@ -16,4 +16,4 @@ When you're ready to build for production, run:
 npm run build
 ```
 
-See [the GitHub repo](https://githb.com/ascorbic/impala) for more help.
+See [the GitHub repo](https://github.com/ascorbic/impala) for more help.

--- a/templates/react-js/README.md
+++ b/templates/react-js/README.md
@@ -16,4 +16,4 @@ When you're ready to build for production, run:
 npm run build
 ```
 
-See [the GitHub repo](https://githb.com/ascorbic/impala) for more help.
+See [the GitHub repo](https://github.com/ascorbic/impala) for more help.

--- a/templates/react-ts/README.md
+++ b/templates/react-ts/README.md
@@ -16,4 +16,4 @@ When you're ready to build for production, run:
 npm run build
 ```
 
-See [the GitHub repo](https://githb.com/ascorbic/impala) for more help.
+See [the GitHub repo](https://github.com/ascorbic/impala) for more help.


### PR DESCRIPTION
Back again with another super minor copy/paste issue 😅 

My ad blocker was less than thrilled to see githb.com when I opened that link